### PR TITLE
Create math page

### DIFF
--- a/_pages/math.html
+++ b/_pages/math.html
@@ -1,5 +1,11 @@
+---
+layout: single
+title: "The Math Behind Intelligence"
+permalink: /math/
+author_profile: true
+---
+
 <section id="math-intelligence">
-  <h2 class="section-title">The Math Behind the Intelligence <span>🧠📐</span></h2>
   <p class="intro">
     I believe that mastering and developing an intuitive understanding of mathematical foundations is the key to building truly intelligent systems.
     This section showcases my commitment to theory-driven robotics and AI — each subject below has been studied rigorously,
@@ -12,7 +18,7 @@
       <img src="/assets/img/dummy-cover-1.jpg" alt="Probability and Distribution Theory">
       <div class="math-content">
         <h3>Probability and Distribution Theory</h3>
-        <p>Casella & Berger — Random variables, expectation, exponential family, convergence theorems.</p>
+        <p>Casella & Berger — Random variables, expectation, exponential family, convergence theorems. Working through every problem strengthens my intuition for handling uncertainty in robotics.</p>
         <a href="https://github.com/SaiSampathKedari/Probability-and-Distribution-Theory" target="_blank">View Repository →</a>
       </div>
     </div>
@@ -21,7 +27,7 @@
       <img src="/assets/img/dummy-cover-2.jpg" alt="Statistical Inference Theory">
       <div class="math-content">
         <h3>Statistical Inference Theory</h3>
-        <p>Casella & Berger — Estimation, MLE, Bayesian inference, hypothesis testing.</p>
+        <p>Casella & Berger — Estimation, MLE, Bayesian inference, hypothesis testing. These exercises train the statistical thinking required for perception algorithms.</p>
         <a href="https://github.com/SaiSampathKedari/Statistical-Inference-Theory" target="_blank">View Repository →</a>
       </div>
     </div>
@@ -30,7 +36,7 @@
       <img src="/assets/img/dummy-cover-3.jpg" alt="Real Analysis">
       <div class="math-content">
         <h3>Real Analysis</h3>
-        <p>Kenneth Ross — Sequences, limits, continuity, uniform convergence, compactness.</p>
+        <p>Kenneth Ross — Sequences, limits, continuity, uniform convergence, compactness. Building rigor here lets me prove convergence and stability of algorithms.</p>
         <a href="https://github.com/SaiSampathKedari/Real-Analysis" target="_blank">View Repository →</a>
       </div>
     </div>
@@ -39,7 +45,7 @@
       <img src="/assets/img/dummy-cover-4.jpg" alt="Convex Optimization">
       <div class="math-content">
         <h3>Convex Optimization</h3>
-        <p>Stephen Boyd — Convex sets, functions, duality, gradient and interior-point methods.</p>
+        <p>Stephen Boyd — Convex sets, functions, duality, gradient and interior-point methods. Solving problems equips me with tools for efficient planning and control.</p>
         <a href="https://github.com/SaiSampathKedari/UMich-IOE611-Convex-Optimization" target="_blank">View Repository →</a>
       </div>
     </div>
@@ -48,7 +54,7 @@
       <img src="/assets/img/dummy-cover-5.jpg" alt="Fourier Transform">
       <div class="math-content">
         <h3>Fourier Transform</h3>
-        <p>Stanford EE261 — Fourier series, spectral representation, convolution, filters.</p>
+        <p>Stanford EE261 — Fourier series, spectral representation, convolution, filters. A deep grasp of transforms aids processing sensor data and images.</p>
         <a href="https://github.com/SaiSampathKedari/Stanford-EE261-The-Fourier-Transform-and-its-Applications" target="_blank">View Repository →</a>
       </div>
     </div>
@@ -57,7 +63,7 @@
       <img src="/assets/img/dummy-cover-6.jpg" alt="Signals and Systems">
       <div class="math-content">
         <h3>Signals and Systems</h3>
-        <p>Oppenheim — LTI systems, Laplace/Z/Fourier transforms, convolution, system stability.</p>
+        <p>Oppenheim — LTI systems, Laplace/Z/Fourier transforms, convolution, system stability. Understanding signals lays the groundwork for reliable dynamic models.</p>
         <a href="https://github.com/SaiSampathKedari/Signals-and-Systems" target="_blank">View Repository →</a>
       </div>
     </div>
@@ -69,11 +75,6 @@
   #math-intelligence {
     padding: 3rem 1rem;
     background: #fdfdfd;
-  }
-  .section-title {
-    font-size: 2.4rem;
-    text-align: center;
-    margin-bottom: 1rem;
   }
   .intro {
     max-width: 720px;


### PR DESCRIPTION
## Summary
- add Math page with blog text and styling
- remove old `_math` folder
- refine descriptions and remove duplicate header

## Testing
- `bundle exec jekyll build --quiet` *(fails: bundler command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c27b4507c8331962dc8b036692ab9