### PR TITLE
Fix math page image paths

### DIFF
--- a/_pages/math.html
+++ b/_pages/math.html
@@ -15,7 +15,7 @@ author_profile: true
   <div class="math-showcase">
 
     <div class="math-tile">
-      <img src="../images/CommonDistributions.png" alt="Cover for Probability and Distribution Theory">
+      <img src="{{ '/images/CommonDistributions.png' | relative_url }}" alt="Cover for Probability and Distribution Theory">
       <div class="math-content">
         <h3>Probability and Distribution Theory</h3>
         <p>Casella & Berger — Random variables, expectation, exponential family, convergence theorems. Working through every problem strengthens my intuition for handling uncertainty in robotics.</p>
@@ -24,7 +24,7 @@ author_profile: true
     </div>
 
     <div class="math-tile">
-      <img src="../images/Statistical-Inference-Theory.jpg" alt="Cover for Statistical Inference Theory">
+      <img src="{{ '/images/Statistical-Inference-Theory.jpg' | relative_url }}" alt="Cover for Statistical Inference Theory">
       <div class="math-content">
         <h3>Statistical Inference Theory</h3>
         <p>Casella & Berger — Estimation, MLE, Bayesian inference, hypothesis testing. These exercises train the statistical thinking required for perception algorithms.</p>
@@ -51,7 +51,7 @@ author_profile: true
     </div>
 
     <div class="math-tile">
-      <img src="../images/Fourier-Transform.jpg" alt="Cover for Fourier Transform">
+      <img src="{{ '/images/Fourier-Transform.jpg' | relative_url }}" alt="Cover for Fourier Transform">
       <div class="math-content">
         <h3>Fourier Transform</h3>
         <p>Stanford EE261 — Fourier series, spectral representation, convolution, filters. A deep grasp of transforms aids processing sensor data and images.</p>


### PR DESCRIPTION
## Summary
- fix relative image paths in math page so they work with Jekyll

## Testing
- `npm run build:js` *(fails: uglifyjs not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c4bf00d1083319035709fb19a62ae