### PR TITLE
Improve math page repo button style

### DIFF
--- a/_pages/math.html
+++ b/_pages/math.html
@@ -15,7 +15,7 @@ author_profile: true
   <div class="math-showcase">
 
     <div class="math-tile">
-      <img src="../images/CommonDistributions.png" alt="Cover for Probability and Distribution Theory">
+      <img src="{{ '/images/CommonDistributions.png' | relative_url }}" alt="Cover for Probability and Distribution Theory">
       <div class="math-content">
         <h3>Probability and Distribution Theory</h3>
         <p>Casella & Berger — Random variables, expectation, exponential family, convergence theorems. Working through every problem strengthens my intuition for handling uncertainty in robotics.</p>
@@ -24,7 +24,7 @@ author_profile: true
     </div>
 
     <div class="math-tile">
-      <img src="../images/Statistical-Inference-Theory.jpg" alt="Cover for Statistical Inference Theory">
+      <img src="{{ '/images/Statistical-Inference-Theory.jpg' | relative_url }}" alt="Cover for Statistical Inference Theory">
       <div class="math-content">
         <h3>Statistical Inference Theory</h3>
         <p>Casella & Berger — Estimation, MLE, Bayesian inference, hypothesis testing. These exercises train the statistical thinking required for perception algorithms.</p>
@@ -51,7 +51,7 @@ author_profile: true
     </div>
 
     <div class="math-tile">
-      <img src="../images/Fourier-Transform.jpg" alt="Cover for Fourier Transform">
+      <img src="{{ '/images/Fourier-Transform.jpg' | relative_url }}" alt="Cover for Fourier Transform">
       <div class="math-content">
         <h3>Fourier Transform</h3>
         <p>Stanford EE261 — Fourier series, spectral representation, convolution, filters. A deep grasp of transforms aids processing sensor data and images.</p>
@@ -74,7 +74,7 @@ author_profile: true
 <style>
   #math-intelligence {
     padding: 3rem 1rem;
-    background: linear-gradient(135deg, #fafafa, #f0f4f9);
+    background: var(--global-bg-color);
   }
   .intro {
     max-width: 720px;
@@ -90,18 +90,21 @@ author_profile: true
     padding: 0 .5rem;
   }
   .math-tile {
-    background: #fff;
-    border-radius: 12px;
-    border: 1px solid #eee;
+    background: rgba(255, 255, 255, 0.35);
+    border-radius: 16px;
+    border: 1px solid rgba(255, 255, 255, 0.3);
     overflow: hidden;
-    box-shadow: 0 2px 8px rgba(0, 0, 0, 0.05);
+    backdrop-filter: blur(8px);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6),
+                0 2px 8px rgba(0, 0, 0, 0.05);
     transition: transform 0.3s ease, box-shadow 0.3s ease;
     display: flex;
     flex-direction: column;
   }
   .math-tile:hover {
     transform: translateY(-6px);
-    box-shadow: 0 8px 20px rgba(0, 0, 0, 0.08);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7),
+                0 8px 20px rgba(0, 0, 0, 0.08);
   }
   .math-tile img {
     width: 100%;
@@ -135,11 +138,19 @@ author_profile: true
     margin-top: 0.75rem;
     display: inline-block;
     font-weight: 600;
-    color: #3366cc;
+    color: var(--global-link-color);
     text-decoration: none;
-    transition: color 0.2s;
+    padding: 0.45rem 0.9rem;
+    border-radius: 12px;
+    background: rgba(255, 255, 255, 0.25);
+    backdrop-filter: blur(6px);
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 2px 6px rgba(0, 0, 0, 0.1);
+    transition: background 0.3s, box-shadow 0.3s, color 0.3s;
   }
   .math-content a:hover {
-    color: #224499;
+    color: var(--global-link-color-hover);
+    background: rgba(255, 255, 255, 0.35);
+    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45), 0 4px 10px rgba(0, 0, 0, 0.15);
   }
 </style>


### PR DESCRIPTION
## Summary
- enhance GitHub repo links with glassy background and rounded corners
- use blur and soft highlights for iOS-style tiles

## Testing
- `npm run build:js` *(fails: uglifyjs not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c4bf00d1083319035709fb19a62ae