### PR TITLE
Improve math showcase design

### DIFF
--- a/_pages/math.html
+++ b/_pages/math.html
@@ -19,7 +19,11 @@ author_profile: true
       <div class="math-content">
         <h3>Probability and Distribution Theory</h3>
         <p>Casella & Berger — Random variables, expectation, exponential family, convergence theorems. Working through every problem strengthens my intuition for handling uncertainty in robotics.</p>
-        <a href="https://github.com/SaiSampathKedari/Probability-and-Distribution-Theory" target="_blank">View on GitHub →</a>
+        <div class="tags"><span>#Probability</span><span>#Distributions</span></div>
+        <a href="https://github.com/SaiSampathKedari/Probability-and-Distribution-Theory" class="github-btn" target="_blank">
+          <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.19 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+          <span>View on GitHub →</span>
+        </a>
       </div>
     </div>
 
@@ -28,7 +32,11 @@ author_profile: true
       <div class="math-content">
         <h3>Statistical Inference Theory</h3>
         <p>Casella & Berger — Estimation, MLE, Bayesian inference, hypothesis testing. These exercises train the statistical thinking required for perception algorithms.</p>
-        <a href="https://github.com/SaiSampathKedari/Statistical-Inference-Theory" target="_blank">View on GitHub →</a>
+        <div class="tags"><span>#Estimation</span><span>#Bayesian</span></div>
+        <a href="https://github.com/SaiSampathKedari/Statistical-Inference-Theory" class="github-btn" target="_blank">
+          <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.19 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+          <span>View on GitHub →</span>
+        </a>
       </div>
     </div>
 
@@ -37,7 +45,11 @@ author_profile: true
       <div class="math-content">
         <h3>Real Analysis</h3>
         <p>Kenneth Ross — Sequences, limits, continuity, uniform convergence, compactness. Building rigor here lets me prove convergence and stability of algorithms.</p>
-        <a href="https://github.com/SaiSampathKedari/Real-Analysis" target="_blank">View on GitHub →</a>
+        <div class="tags"><span>#Sequences</span><span>#Limits</span></div>
+        <a href="https://github.com/SaiSampathKedari/Real-Analysis" class="github-btn" target="_blank">
+          <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.19 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+          <span>View on GitHub →</span>
+        </a>
       </div>
     </div>
 
@@ -46,7 +58,11 @@ author_profile: true
       <div class="math-content">
         <h3>Convex Optimization</h3>
         <p>Stephen Boyd — Convex sets, functions, duality, gradient and interior-point methods. Solving problems equips me with tools for efficient planning and control.</p>
-        <a href="https://github.com/SaiSampathKedari/UMich-IOE611-Convex-Optimization" target="_blank">View on GitHub →</a>
+        <div class="tags"><span>#Optimization</span><span>#Duality</span></div>
+        <a href="https://github.com/SaiSampathKedari/UMich-IOE611-Convex-Optimization" class="github-btn" target="_blank">
+          <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.19 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+          <span>View on GitHub →</span>
+        </a>
       </div>
     </div>
 
@@ -55,7 +71,11 @@ author_profile: true
       <div class="math-content">
         <h3>Fourier Transform</h3>
         <p>Stanford EE261 — Fourier series, spectral representation, convolution, filters. A deep grasp of transforms aids processing sensor data and images.</p>
-        <a href="https://github.com/SaiSampathKedari/Stanford-EE261-The-Fourier-Transform-and-its-Applications" target="_blank">View on GitHub →</a>
+        <div class="tags"><span>#Spectral</span><span>#Signals</span></div>
+        <a href="https://github.com/SaiSampathKedari/Stanford-EE261-The-Fourier-Transform-and-its-Applications" class="github-btn" target="_blank">
+          <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.19 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+          <span>View on GitHub →</span>
+        </a>
       </div>
     </div>
 
@@ -64,7 +84,11 @@ author_profile: true
       <div class="math-content">
         <h3>Signals and Systems</h3>
         <p>Oppenheim — LTI systems, Laplace/Z/Fourier transforms, convolution, system stability. Understanding signals lays the groundwork for reliable dynamic models.</p>
-        <a href="https://github.com/SaiSampathKedari/Signals-and-Systems" target="_blank">View on GitHub →</a>
+        <div class="tags"><span>#LTI</span><span>#Transforms</span></div>
+        <a href="https://github.com/SaiSampathKedari/Signals-and-Systems" class="github-btn" target="_blank">
+          <svg viewBox="0 0 16 16" aria-hidden="true"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.19 0 .21.15.46.55.38A8.013 8.013 0 0 0 16 8c0-4.42-3.58-8-8-8z"/></svg>
+          <span>View on GitHub →</span>
+        </a>
       </div>
     </div>
 
@@ -72,85 +96,115 @@ author_profile: true
 </section>
 
 <style>
-  #math-intelligence {
-    padding: 3rem 1rem;
-    background: var(--global-bg-color);
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;600&family=Roboto+Slab:wght@600&display=swap');
+:root {
+  --card-bg: rgba(255,255,255,0.6);
+  --card-shadow: 0 6px 20px rgba(0,0,0,0.1);
+  --card-shadow-hover: 0 12px 24px rgba(0,0,0,0.15);
+  --font-body: 'Inter', sans-serif;
+  --font-heading: 'Roboto Slab', serif;
+  --button-bg: #fff;
+  --button-hover: #eef2f3;
+}
+@media (prefers-color-scheme: dark) {
+  :root {
+    --card-bg: rgba(40,40,40,0.6);
+    --button-bg: #333;
+    --button-hover: #444;
   }
-  .intro {
-    max-width: 720px;
-    margin: 0 auto 2rem;
-    text-align: center;
-    font-size: 1.1rem;
-    color: #444;
-  }
-  .math-showcase {
-    display: grid;
-    grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-    gap: 1.5rem;
-    padding: 0 .5rem;
-  }
-  .math-tile {
-    background: rgba(255, 255, 255, 0.35);
-    border-radius: 16px;
-    border: 1px solid rgba(255, 255, 255, 0.3);
-    overflow: hidden;
-    backdrop-filter: blur(8px);
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.6),
-                0 2px 8px rgba(0, 0, 0, 0.05);
-    transition: transform 0.3s ease, box-shadow 0.3s ease;
-    display: flex;
-    flex-direction: column;
-  }
-  .math-tile:hover {
-    transform: translateY(-6px);
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.7),
-                0 8px 20px rgba(0, 0, 0, 0.08);
-  }
-  .math-tile img {
-    width: 100%;
-    height: 180px;
-    object-fit: cover;
-  }
-  @media (min-width: 600px) {
-    .math-tile img {
-      height: 220px;
-    }
-  }
-  .math-content {
-    padding: 1rem 1.25rem 1.5rem;
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-  }
-  .math-content h3 {
-    margin-top: 0;
-    font-size: 1.25rem;
-    color: #222;
-    font-family: 'Roboto Slab', 'Cambria', 'Times New Roman', serif;
-  }
-  .math-content p {
-    color: #555;
-    font-size: 0.95rem;
-    line-height: 1.55;
-    flex: 1;
-  }
-  .math-content a {
-    margin-top: 0.75rem;
-    display: inline-block;
-    font-weight: 600;
-    color: var(--global-link-color);
-    text-decoration: none;
-    padding: 0.45rem 0.9rem;
-    border-radius: 12px;
-    background: rgba(255, 255, 255, 0.25);
-    backdrop-filter: blur(6px);
-    border: 1px solid rgba(255, 255, 255, 0.3);
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 2px 6px rgba(0, 0, 0, 0.1);
-    transition: background 0.3s, box-shadow 0.3s, color 0.3s;
-  }
-  .math-content a:hover {
-    color: var(--global-link-color-hover);
-    background: rgba(255, 255, 255, 0.35);
-    box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45), 0 4px 10px rgba(0, 0, 0, 0.15);
-  }
+}
+#math-intelligence {
+  padding: 4rem 1rem;
+  background: linear-gradient(to right, #eef2f3, #ffffff);
+  font-family: var(--font-body);
+}
+.intro {
+  max-width: 720px;
+  margin: 0 auto 2rem;
+  text-align: center;
+  font-size: 1.1rem;
+  color: var(--global-text-color);
+}
+.math-showcase {
+  display: grid;
+  gap: 1.5rem;
+}
+@media (min-width: 600px) {
+  .math-showcase { grid-template-columns: repeat(2, 1fr); }
+}
+@media (min-width: 900px) {
+  .math-showcase { grid-template-columns: repeat(3, 1fr); }
+}
+.math-tile {
+  background: var(--card-bg);
+  border-radius: 16px;
+  overflow: hidden;
+  backdrop-filter: blur(10px);
+  box-shadow: var(--card-shadow);
+  transition: transform 0.3s ease, box-shadow 0.3s ease;
+  display: flex;
+  flex-direction: column;
+}
+.math-tile:hover {
+  transform: scale(1.03);
+  box-shadow: var(--card-shadow-hover);
+}
+.math-tile img {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+}
+.math-content {
+  padding: 1rem 1.25rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+}
+.math-content h3 {
+  margin-top: 0;
+  font-size: 1.25rem;
+  font-family: var(--font-heading);
+  color: var(--global-text-color);
+}
+.math-content p {
+  flex: 1;
+  font-size: 0.95rem;
+  color: var(--global-text-color);
+  line-height: 1.55;
+}
+.tags {
+  margin-top: 0.5rem;
+}
+.tags span {
+  display: inline-block;
+  background: rgba(0,0,0,0.05);
+  padding: 2px 8px;
+  border-radius: 8px;
+  font-size: 0.75rem;
+  margin-right: 0.3rem;
+}
+.github-btn {
+  margin-top: 1rem;
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  padding: 0.5rem 1rem;
+  background: var(--button-bg);
+  border-radius: 12px;
+  text-decoration: none;
+  color: var(--global-link-color);
+  font-weight: 600;
+  box-shadow: 0 2px 6px rgba(0,0,0,0.1);
+  transition: background 0.3s, box-shadow 0.3s;
+}
+.github-btn svg {
+  width: 1rem;
+  height: 1rem;
+  margin-right: 0.5rem;
+  fill: currentColor;
+}
+.github-btn:hover {
+  background: var(--button-hover);
+  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
+}
 </style>


### PR DESCRIPTION
## Summary
- redesign math showcase page with modern card style
- add Google fonts and gradient background
- style GitHub buttons with icons and tags

## Testing
- `bundle exec jekyll build --quiet` *(fails: command not found)*
- `npm run build:js` *(fails: uglifyjs not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c5ea39764833186fc140796f36c76