### PR TITLE
Add Differential Equations repo link

### DIFF
--- a/_pages/math.html
+++ b/_pages/math.html
@@ -68,6 +68,14 @@ author_profile: true
       </div>
     </div>
 
+    <div class="math-tile">
+      <img src="{{ '/images/Differential-Equations.png' | relative_url }}" alt="Cover for Differential Equations">
+      <div class="math-content">
+        <h3>Differential Equations</h3>
+        <p>MIT 18.03 & Edwards-Penney — Lecture notes and solved problems on first- and second-order ODEs, Laplace transforms, linear systems, and nonlinear dynamics. Essential for modeling real-world robotics and control systems.</p>
+        <a href="https://github.com/SaiSampathKedari/Differential-Equations" target="_blank">View on GitHub →</a>
+      </div>
+    </div>
   </div>
 </section>
 


### PR DESCRIPTION
## Summary
- feature: link MIT differential equations repo in the math page

## Testing
- `npm run build:js` *(fails: uglifyjs not found)*

------
https://chatgpt.com/codex/tasks/task_e_684c66cb3d9c833181e5a92e8bd71144