### PR TITLE
Match heading styles on math page

### DIFF
--- a/_pages/math.html
+++ b/_pages/math.html
@@ -132,8 +132,10 @@ author_profile: true
   }
   .math-content h3 {
     margin-top: 0;
-    font-size: 1.25rem;
-    color: #222;
+    font-size: 1.5rem;
+    font-weight: 600;
+    color: #007bff;
+    margin-bottom: 0.75rem;
     font-family: 'Roboto Slab', 'Cambria', 'Times New Roman', serif;
   }
   .math-content p {
@@ -146,18 +148,18 @@ author_profile: true
     margin-top: 0.75rem;
     display: inline-block;
     font-weight: 600;
-    color: var(--global-link-color);
+    color: #007bff;
     text-decoration: none;
     padding: 0.45rem 0.9rem;
     border-radius: 12px;
     background: rgba(255, 255, 255, 0.25);
     backdrop-filter: blur(6px);
-    border: 1px solid rgba(255, 255, 255, 0.3);
+    border: 1px solid #007bff;
     box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.4), 0 2px 6px rgba(0, 0, 0, 0.1);
     transition: background 0.3s, box-shadow 0.3s, color 0.3s;
   }
   .math-content a:hover {
-    color: var(--global-link-color-hover);
+    color: #0056b3;
     background: rgba(255, 255, 255, 0.35);
     box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.45), 0 4px 10px rgba(0, 0, 0, 0.15);
   }


### PR DESCRIPTION
## Summary
- tweak `.math-content h3` style in math.html to match about page headers
- color GitHub links blue to match headings

## Testing
- `npm run build:js` *(fails: uglifyjs not found)*

------
https://chatgpt.com/codex/tasks/task_e_684ca02434e48331a49665f8eabac3ce