### PR TITLE
Refine coursework headers

### DIFF
--- a/_pages/about.html
+++ b/_pages/about.html
@@ -53,6 +53,49 @@ author_profile: true
       </li>
     </ul>
   </section>
+  <section class="section">
+    <div class="icon-heading">
+      <i class="fas fa-book"></i>
+      <span>Selected Graduate Coursework</span>
+    </div>
+    <p><strong>Focus Areas:</strong> Machine Learning · Bayesian Inference · Convex Optimization · Control Theory · Statistical Estimation · Stochastic Processes · Nonlinear Dynamics</p>
+
+    <div class="coursework-section">
+
+      <div class="course-block">
+        <div class="course-header">Inference, Learning, and Optimization</div>
+        <div class="course-list">
+          <div class="course-pill"><span class="course-code">EECS 505</span><span class="course-title">Computational Data Science and Machine Learning</span></div>
+          <div class="course-pill"><span class="course-code">IOE 611</span><span class="course-title">Nonlinear Programming</span></div>
+          <div class="course-pill"><span class="course-code">AEROSP 567</span><span class="course-title">Inference, Estimation, and Learning</span></div>
+          <div class="course-pill"><span class="course-code">EECS 553</span><span class="course-title">Machine Learning (ECE)</span></div>
+        </div>
+      </div>
+
+      <div class="course-block">
+        <div class="course-header">Statistics and Mathematical Foundations</div>
+        <div class="course-list">
+          <div class="course-pill"><span class="course-code">STATS 510</span><span class="course-title">Probability and Distribution Theory</span></div>
+          <div class="course-pill"><span class="course-code">STATS 511</span><span class="course-title">Statistical Theory</span></div>
+          <div class="course-pill"><span class="course-code">IOE 516</span><span class="course-title">Stochastic Processes II</span></div>
+          <div class="course-pill"><span class="course-code">ROB 501</span><span class="course-title">Mathematics for Robotics</span></div>
+          <div class="course-pill"><span class="course-code">MATH 558</span><span class="course-title">Applied Nonlinear Dynamics</span></div>
+        </div>
+      </div>
+
+      <div class="course-block">
+        <div class="course-header">Control Theory and Dynamical Systems</div>
+        <div class="course-list">
+          <div class="course-pill"><span class="course-code">EECS 460</span><span class="course-title">Control Systems Analysis and Design</span></div>
+          <div class="course-pill"><span class="course-code">EECS 560</span><span class="course-title">Linear Systems Theory</span></div>
+          <div class="course-pill"><span class="course-code">EECS 562</span><span class="course-title">Nonlinear Systems and Control</span></div>
+          <div class="course-pill"><span class="course-code">EECS 565</span><span class="course-title">Linear Feedback Control</span></div>
+        </div>
+      </div>
+
+    </div>
+
+  </section>
 </div>
 
 <style>
@@ -99,5 +142,82 @@ body {
 
 .icon-heading i {
   color: #007bff;
+}
+.section-title {
+  color: #2b6cb0;
+}
+
+.coursework-section {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  margin-top: 2rem;
+}
+
+.course-block {
+  border-radius: 10px;
+  overflow: hidden;
+  box-shadow: 0 4px 8px rgba(0,0,0,0.06);
+  border: 1px solid #ddd;
+}
+
+.course-header {
+  background-color: #007bff;
+  color: #fff;
+  padding: 0.75rem 1rem;
+  font-weight: 600;
+  font-size: 1.15rem;
+  letter-spacing: 0.3px;
+}
+
+.course-list {
+  background-color: #fff;
+  padding: 1rem 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.course-pill {
+  background-color: #fff;
+  color: #1c1c1e;
+  padding: 0.6rem 1rem;
+  border-radius: 8px;
+  font-size: 1rem;
+  font-weight: 500;
+  border-left: 4px solid #007bff;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.04);
+  line-height: 1.4;
+  display: flex;
+  transition: transform 0.2s ease, background-color 0.2s ease;
+}
+
+.course-pill:hover {
+  background-color: #f5f5f5;
+  transform: translateX(4px);
+  cursor: default;
+}
+
+.course-code {
+  width: 140px;
+  font-weight: 700;
+  color: #1c1c1e;
+  flex-shrink: 0;
+}
+
+.course-title {
+  font-weight: 500;
+  color: #1c1c1e;
+  padding-left: 0.5rem;
+}
+
+@media (max-width: 480px) {
+  .course-code {
+    width: 110px;
+    font-size: 0.9rem;
+  }
+  .course-title {
+    font-size: 0.9rem;
+  }
 }
 </style>


### PR DESCRIPTION
## Summary
- keep existing sections intact
- style coursework group headers with blue background and white text

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684d7f58cc2883319e2586e167dd247f