### PR TITLE
Add X feed embed to About page

### DIFF
--- a/_pages/about.html
+++ b/_pages/about.html
@@ -96,6 +96,15 @@ author_profile: true
     </div>
 
   </section>
+  <section class="section">
+    <div class="icon-heading">
+      <i class="fa-brands fa-x-twitter"></i>
+      <span>Latest Tweets</span>
+    </div>
+    <a class="twitter-timeline" data-height="600" href="https://x.com/SSampathKedari">Tweets by @SSampathKedari</a>
+    <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+  </section>
+
 </div>
 
 <style>


### PR DESCRIPTION
## Summary
- embed X (Twitter) timeline after the coursework section on About page

## Testing
- `npm run build:js` *(fails: uglifyjs not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d9379f9f083319afb245c1571748e