### PR TITLE
Add CV HTML viewer page

### DIFF
--- a/_pages/cv.html
+++ b/_pages/cv.html
@@ -1,0 +1,53 @@
+---
+layout: single
+title: "CV"
+permalink: /cvpdf/
+author_profile: true
+---
+
+{% include base_path %}
+
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css">
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@500;600&display=swap" rel="stylesheet" />
+
+<div class="cv-button" style="margin-bottom:1rem;">
+  <a href="{{ base_path }}/files/Resume_SaiSampathKedari.pdf" target="_blank" aria-label="Download Resume">
+    <i class="fas fa-file-pdf"></i> Download Resume
+  </a>
+</div>
+
+<div class="pdf-viewer">
+  <iframe src="{{ base_path }}/files/Resume_SaiSampathKedari.pdf" width="100%" height="800px" style="border:none;">
+    <p>Your browser does not support iframes. You can <a href="{{ base_path }}/files/Resume_SaiSampathKedari.pdf" target="_blank">download the PDF</a> instead.</p>
+  </iframe>
+</div>
+
+<style>
+  .cv-button a {
+    font-family: 'Inter', sans-serif;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-weight: 600;
+    padding: 0.4rem 0.9rem;
+    background: #2b6cb0;
+    color: #ffffff;
+    border-radius: 8px;
+    font-size: 0.75rem;
+    text-decoration: none;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
+    border: 1px solid #2b6cb0;
+    transition: background 0.3s, transform 0.2s, box-shadow 0.3s;
+    display: inline-block;
+  }
+
+  .cv-button a:hover {
+    background: #1a416f;
+    transform: translateY(-2px);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.12);
+  }
+
+  .cv-button a:active {
+    transform: translateY(0);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.08);
+  }
+</style>


### PR DESCRIPTION
## Summary
- create a new page `_pages/cv.html` with layout `single`
- add a button linking to the resume PDF
- embed the PDF in an iframe so it can be scrolled on the page
- style the button like other pages

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_684d993fbf3c833189d25e4a481f1890