### PR TITLE
Add custom Teaching page

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -34,6 +34,9 @@ main:
     
   - title: "Resume"
     url: /cvpdf/
+
+  - title: "Teaching"
+    url: /teaching/
     
   # - title: "CV"
   #   url: /cv-json/

--- a/_pages/teaching.html
+++ b/_pages/teaching.html
@@ -1,12 +1,89 @@
 ---
-layout: archive
+layout: single
 title: "Teaching"
 permalink: /teaching/
 author_profile: true
 ---
 
-{% include base_path %}
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.0/css/all.min.css" />
 
-{% for post in site.teaching reversed %}
-  {% include archive-single.html %}
-{% endfor %}
+<div class="container">
+  <section class="section">
+    <div class="icon-heading">
+      <i class="fas fa-chalkboard-teacher"></i>
+      <span>Teaching Experience</span>
+    </div>
+
+    <p>I served as a Graduate Student Instructor (GSI) for core undergraduate physics courses at the University of Michigan from Fall 2022 to Winter 2024, supporting labs, discussion sections, and exams.</p>
+
+    <ul class="teaching-list">
+      <li class="teaching-item">
+        <img src="/assets/images/um_logo.png" alt="UM Logo" />
+        <div>
+          <strong>PHYSICS 241: General Physics II (Electromagnetism and Special Relativity)</strong><br>
+          <em>Fall 2022 (FA 2022), Winter 2023 (WN 2023) &mdash; Prof. Lorenzon</em><br>
+          Topics: Electric &amp; Magnetic Fields, DC/AC Circuits, Lorentz Force, Faraday&rsquo;s Law, and Special Relativity.
+        </div>
+      </li>
+      <li class="teaching-item">
+        <img src="/assets/images/um_logo.png" alt="UM Logo" />
+        <div>
+          <strong>PHYSICS/BIOPHYS 151: Introductory Physics Lab for Life Sciences</strong><br>
+          <em>Spring 2023 (SP 2023)</em><br>
+          Topics: Scaling, Statistics, Mechanics, Fluid Dynamics, and Biophysics applications (e.g., blood pressure, calorimetry).
+        </div>
+      </li>
+      <li class="teaching-item">
+        <img src="/assets/images/um_logo.png" alt="UM Logo" />
+        <div>
+          <strong>PHYSICS 360: Thermodynamics, Waves, and Special Relativity</strong><br>
+          <em>Fall 2023 (FA 2023) &mdash; Prof. Jianming Qian<br>Winter 2024 (WN 2024) &mdash; Prof. Lu Li</em><br>
+          Topics: Thermodynamics, Wave Phenomena, Geometric Optics, and Special Relativity.
+        </div>
+      </li>
+    </ul>
+  </section>
+</div>
+
+<style>
+.container {
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 2rem 1rem;
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif;
+}
+.section {
+  background: #fff;
+  padding: 2rem;
+  border-radius: 12px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+  margin-bottom: 2rem;
+}
+.icon-heading {
+  display: flex;
+  align-items: center;
+  font-size: 1.5rem;
+  font-weight: 600;
+  color: #007bff;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+}
+.icon-heading i {
+  color: #007bff;
+}
+.teaching-list {
+  padding-left: 1.2rem;
+}
+.teaching-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+  line-height: 1.6;
+}
+.teaching-item img {
+  height: 48px;
+  flex-shrink: 0;
+  margin-top: 4px;
+}
+</style>


### PR DESCRIPTION
## Summary
- replace the previous teaching archive page with a custom page that lists GSI roles
- add a Teaching entry in site navigation

## Testing
- `bundle exec jekyll build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684dc68e79c48331b835a67e938ed3c0