### PR TITLE
Fix mobile footer layout on projects page

### DIFF
--- a/_pages/projects.html
+++ b/_pages/projects.html
@@ -296,6 +296,15 @@ setupCarousel('carousel5');
   .project-card-content {
     height: 45%;
   }
+
+  .project-footer {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 0.75rem;
+  }
+  .tags, .project-buttons {
+    margin-top: 0.5rem;
+  }
 }
 
 .tags {


### PR DESCRIPTION
## Summary
- keep GitHub and report buttons visible on small screens

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684debbfce3083319345032d5b27a22d