### PR TITLE
Switch to 2-column grid with fixed aspect-ratio media containers

### DIFF
--- a/_sass/_custom.scss
+++ b/_sass/_custom.scss
@@ -636,10 +636,6 @@ section {
   @media (min-width: 768px) {
     grid-template-columns: repeat(2, 1fr);
   }
-
-  @media (min-width: 1200px) {
-    grid-template-columns: repeat(3, 1fr);
-  }
 }
 
 .inference-viz-card {
@@ -656,13 +652,15 @@ section {
     padding: 10px;
     background: #f8fafd;
     border-radius: 16px 16px 0 0;
-    max-height: 320px;
+    aspect-ratio: 16 / 10;
+    display: flex;
+    align-items: center;
+    justify-content: center;
     overflow: hidden;
 
     video {
       width: 100%;
-      height: auto;
-      max-height: 300px;
+      height: 100%;
       object-fit: contain;
     }
   }
@@ -673,17 +671,17 @@ section {
   }
 
   .monte-carlo-card-content {
-    padding: 12px 14px 14px;
+    padding: 12px 16px 16px;
     gap: 0.3rem;
 
     h3 {
-      font-size: 0.95rem;
+      font-size: 1rem;
       line-height: 1.3;
     }
 
     .monte-carlo-caption {
-      font-size: 0.8rem;
-      line-height: 1.4;
+      font-size: 0.82rem;
+      line-height: 1.45;
     }
   }
 
@@ -713,7 +711,12 @@ section {
   }
 
   .carousel {
-    height: 280px;
+    width: 100%;
+    height: 100%;
+
+    img {
+      object-fit: contain;
+    }
   }
 }
 


### PR DESCRIPTION
- Remove 3-column breakpoint, keep 2-column at 768px+
- Use aspect-ratio: 16/10 on media containers so all cards have consistent heights regardless of video dimensions
- Carousel images use object-fit: contain within the fixed container
- Slightly larger card typography for better readability at 2-col width

https://claude.ai/code/session_013VuMCB4KiH24zHE1cJYzQX